### PR TITLE
class for api calls closes #5

### DIFF
--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -5,6 +5,7 @@ from rest_framework.decorators import (
     authentication_classes,
     permission_classes,
 )
+from rest_framework.exceptions import APIException
 
 from .tasks import send_email_debug_task
 
@@ -24,8 +25,7 @@ def trigger_exception(request):
     """
     Triggers an exception. used for testing
     """
-    raise Exception("Triggering Exception...")
-
+    raise APIException("Exception message from the API server")
 
 @api_view(["POST"])
 @authentication_classes([])

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -53,7 +53,6 @@ export default class ApiService {
       const { data } = await api.post<TokenResponse>('/api/auth/jwt/token/', loginData, { withCredentials: true });
       return [null, data];
     } catch (error) {
-      console.error(error);
       return [error]
     }
   }
@@ -68,7 +67,6 @@ export default class ApiService {
       const { data } = await api.post<LogoutData>('/api/auth/jwt/token/logout/')
       return [null, data]
     } catch (error) {
-      console.error(error);
       return [error]
     }
   }
@@ -81,7 +79,6 @@ export default class ApiService {
       const { data } = await api.post<TokenResponse>('/api/auth/jwt/token/refresh/')
       return [null, data]
     } catch (error) {
-      console.error(error);
       return [error]
     }
   }
@@ -97,7 +94,6 @@ export default class ApiService {
       const { data } = await api.get<ProfileType>('/api/profile/')
       return [null, data]
     } catch(error) {
-      console.error(error);
       return [error]
     }
   }
@@ -107,7 +103,6 @@ export default class ApiService {
       const { data } = await api.post<PostType>('/api/drf/fbv/posts/new/', formData)
       return [null, data]
     } catch(error) {
-      console.error(error);
       return [error]
     }
   }
@@ -117,7 +112,6 @@ export default class ApiService {
       const { data } = await api.get<PostsType>('/api/drf/fbv/posts/', options)
       return [null, data]
     } catch(error) {
-      console.error(error);
       return [error]
     }
   }
@@ -127,7 +121,6 @@ export default class ApiService {
       const { data } = await api.post<PostType>(`/api/drf/fbv/posts/${postId}/like/`)
       return [null, data]
     } catch(error) {
-      console.error(error);
       return [error]
     }
   }
@@ -137,7 +130,6 @@ export default class ApiService {
       const { data } = await api.get<PostType>(`/api/drf/fbv/posts/${postId}/`)
       return [null, data]
     } catch(error) {
-      console.error(error);
       return [error]
     }
   }
@@ -148,7 +140,6 @@ export default class ApiService {
       const { data } = await api.delete<PostType>(`/api/drf/fbv/posts/${postId}/`)
       return [null, data]
     } catch(error) {
-      console.error(error);
       return [error]
     }
   }

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -5,10 +5,12 @@
 import { api } from 'boot/axios';
 
 import {
+  CreatePostResponse,
   LoginData,
   LogoutData,
   LoginResponse,
   LogoutResponse,
+  PostType,
   ProfileResponse,
   ProfileType,
   RefreshResponse,
@@ -86,6 +88,16 @@ export default class ApiService {
   async profile(): Promise<ProfileResponse> {
     try {
       const { data } = await api.get<ProfileType>('/api/profile/')
+      return [null, data]
+    } catch(error) {
+      console.error(error);
+      return [error]
+    }
+  }
+
+  async createPost(formData: FormData): Promise<CreatePostResponse> {
+    try {
+      const { data } = await api.post<PostType>('/api/drf/fbv/posts/new/', formData)
       return [null, data]
     } catch(error) {
       console.error(error);

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -144,6 +144,7 @@ export default class ApiService {
 
   async deletePost(postId: number): Promise<GetPostResponse> {
     try {
+      // TODO use a different Type here since this does not return a PostType
       const { data } = await api.delete<PostType>(`/api/drf/fbv/posts/${postId}/`)
       return [null, data]
     } catch(error) {

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -1,4 +1,10 @@
+/**
+ * This file defines all backend REST API endpoint calls with axios
+ */
+
 import { api } from 'boot/axios';
+
+import { TokenResponse, LoginData, LoginResponse, LogoutResponse, LogoutData, RefreshResponse } from '../types'
 
 /**
  * class for making backend API calls
@@ -7,22 +13,57 @@ import { api } from 'boot/axios';
  */
 export default class ApiService {
 
+  // /**
+  //  * Activate a user account
+  //  *
+  //  * @param uidb64
+  //  * @param token
+  //  * @returns
+  //  */
+  // static activate(uidb64: string, token: string): Promise<unknown> {
+  //   return api.post(`/api/activate/${uidb64}/${token}/`);
+  // }
+
   /**
-   * Activate a user account
-   *
-   * @param uidb64
-   * @param token
-   * @returns
+   * Login a user
+   * @param {String} username
+   * @param {String} password
+   * @returns {String} Access token
    */
-  static activate(uidb64: string, token: string): Promise<unknown> {
-    return api.post(`/api/activate/${uidb64}/${token}/`);
+  async login(loginData: LoginData): Promise<LoginResponse> {
+    try {
+      const { data } = await api.post<TokenResponse>('/api/auth/jwt/token/', loginData, { withCredentials: true });
+      return [null, data];
+    } catch (error) {
+      console.error(error);
+      return [error]
+    }
   }
 
   /**
    * Logout
    */
-  static logout(): Promise<unknown> {
-    return api.post('/api/auth/jwt/token/logout/')
+  async logout(): Promise<LogoutResponse> {
+    try {
+      const { data } = await api.post<LogoutData>('/api/auth/jwt/token/logout/')
+      return [null, data]
+    } catch (error) {
+      console.error(error);
+      return [error]
+    }
+  }
+
+  /**
+   * Refresh token
+   */
+  async refreshToken(): Promise<RefreshResponse> {
+    try {
+      const { data } = await api.post<TokenResponse>('/api/auth/jwt/token/refresh/')
+      return [null, data]
+    } catch (error) {
+      console.error(error);
+      return [error]
+    }
   }
 
 }

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -1,5 +1,7 @@
 /**
  * This file defines all backend REST API endpoint calls with axios
+ *
+ * Reference article: https://dev.to/blindkai/managing-api-layers-in-vue-js-with-typescript-hno
  */
 
 import { api } from 'boot/axios';
@@ -17,6 +19,7 @@ import {
   ProfileResponse,
   ProfileType,
   RefreshResponse,
+  TogglePostLikeResponse,
   TokenResponse,
 } from '../types'
 
@@ -118,6 +121,15 @@ export default class ApiService {
     }
   }
 
+  async togglePostLike(postId: number): Promise<TogglePostLikeResponse> {
+    try {
+      const { data } = await api.post<PostType>(`/api/drf/fbv/posts/${postId}/like/`)
+      return [null, data]
+    } catch(error) {
+      console.error(error);
+      return [error]
+    }
+  }
 }
 
 // import apiService into modules when making API calls

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -6,10 +6,13 @@ import { api } from 'boot/axios';
 
 import {
   CreatePostResponse,
+  GetPostsResponse,
+  GetPostsOptionsType,
   LoginData,
   LogoutData,
   LoginResponse,
   LogoutResponse,
+  PostsType,
   PostType,
   ProfileResponse,
   ProfileType,
@@ -98,6 +101,16 @@ export default class ApiService {
   async createPost(formData: FormData): Promise<CreatePostResponse> {
     try {
       const { data } = await api.post<PostType>('/api/drf/fbv/posts/new/', formData)
+      return [null, data]
+    } catch(error) {
+      console.error(error);
+      return [error]
+    }
+  }
+
+  async getPosts(options: GetPostsOptionsType): Promise<GetPostsResponse> {
+    try {
+      const { data } = await api.get<PostsType>('/api/drf/fbv/posts/', options)
       return [null, data]
     } catch(error) {
       console.error(error);

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -8,6 +8,7 @@ import { api } from 'boot/axios';
 
 import {
   CreatePostResponse,
+  GetPostResponse,
   GetPostsResponse,
   GetPostsOptionsType,
   LoginData,
@@ -124,6 +125,16 @@ export default class ApiService {
   async togglePostLike(postId: number): Promise<TogglePostLikeResponse> {
     try {
       const { data } = await api.post<PostType>(`/api/drf/fbv/posts/${postId}/like/`)
+      return [null, data]
+    } catch(error) {
+      console.error(error);
+      return [error]
+    }
+  }
+
+  async getPost(postId: number): Promise<GetPostResponse> {
+    try {
+      const { data } = await api.get<PostType>(`/api/drf/fbv/posts/${postId}/`)
       return [null, data]
     } catch(error) {
       console.error(error);

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -8,6 +8,10 @@ import { api } from 'boot/axios';
 
 import {
   CreatePostResponse,
+  EmailAdminResponse,
+  EmailAdminType,
+  ExceptionResponse,
+  ExceptionType,
   GetPostResponse,
   GetPostsResponse,
   GetPostsOptionsType,
@@ -138,6 +142,24 @@ export default class ApiService {
     try {
       // TODO use a different Type here since this does not return a PostType
       const { data } = await api.delete<PostType>(`/api/drf/fbv/posts/${postId}/`)
+      return [null, data]
+    } catch(error) {
+      return [error]
+    }
+  }
+
+  async triggerException(): Promise<ExceptionResponse> {
+    try {
+      const { data } = await api.post<ExceptionType>('/api/exception/')
+      return [null, data]
+    } catch(error) {
+      return [error]
+    }
+  }
+
+  async emailAdmins(): Promise<EmailAdminResponse> {
+    try {
+      const { data } = await api.post<EmailAdminType>('/api/email-admins/')
       return [null, data]
     } catch(error) {
       return [error]

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -141,6 +141,16 @@ export default class ApiService {
       return [error]
     }
   }
+
+  async deletePost(postId: number): Promise<GetPostResponse> {
+    try {
+      const { data } = await api.delete<PostType>(`/api/drf/fbv/posts/${postId}/`)
+      return [null, data]
+    } catch(error) {
+      console.error(error);
+      return [error]
+    }
+  }
 }
 
 // import apiService into modules when making API calls

--- a/quasar-app/src/classes/index.ts
+++ b/quasar-app/src/classes/index.ts
@@ -4,7 +4,16 @@
 
 import { api } from 'boot/axios';
 
-import { TokenResponse, LoginData, LoginResponse, LogoutResponse, LogoutData, RefreshResponse } from '../types'
+import {
+  LoginData,
+  LogoutData,
+  LoginResponse,
+  LogoutResponse,
+  ProfileResponse,
+  ProfileType,
+  RefreshResponse,
+  TokenResponse,
+} from '../types'
 
 /**
  * class for making backend API calls
@@ -42,6 +51,8 @@ export default class ApiService {
 
   /**
    * Logout
+   *
+   * This API call removes the HttpOnly refresh token cookie to logout the current logged in user
    */
   async logout(): Promise<LogoutResponse> {
     try {
@@ -66,4 +77,23 @@ export default class ApiService {
     }
   }
 
+  /**
+   *
+   * Get user profile
+   *
+   * @returns {ProfileResponse}
+   */
+  async profile(): Promise<ProfileResponse> {
+    try {
+      const { data } = await api.get<ProfileType>('/api/profile/')
+      return [null, data]
+    } catch(error) {
+      console.error(error);
+      return [error]
+    }
+  }
+
 }
+
+// import apiService into modules when making API calls
+export const apiService = new ApiService();

--- a/quasar-app/src/modules/auth.ts
+++ b/quasar-app/src/modules/auth.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-
 import { ref, computed } from 'vue';
 import ApiService from '../classes';
 import { Notify } from 'quasar'
@@ -23,7 +18,7 @@ export default function useAuth() {
 
   const router = useRouter();
 
-  const logout = async (): Promise<any> => {
+  const logout = async (): Promise<void> => {
     const [error, data] = await api.logout();
     if (error) console.log('error logging in');
     else {

--- a/quasar-app/src/modules/auth.ts
+++ b/quasar-app/src/modules/auth.ts
@@ -4,28 +4,16 @@
 
 
 import { ref, computed } from 'vue';
-import { api } from 'boot/axios';
 import ApiService from '../classes';
-import { AxiosError } from 'axios';
 import { Notify } from 'quasar'
 import { useRouter } from 'vue-router';
 import useProfile from './profile';
 
-
-type TokenResponse = {
-  access: string;
-}
+// instantiate ApiService
+const api = new ApiService();
 
 const email = ref('');
 const password = ref('');
-
-// ignore unsafe return of any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isAxiosError<T>(error: AxiosError | any): error is AxiosError<T> {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return error && error.isAxiosError
-}
-
 
 const { getProfile, clearProfile } = useProfile();
 
@@ -36,11 +24,14 @@ export default function useAuth() {
   const router = useRouter();
 
   const logout = async (): Promise<any> => {
-    // await api.post('/api/auth/jwt/token/logout/');
-    await ApiService.logout();
-    accessToken.value = '';
-    clearProfile();
-    await router.push('/');
+    const [error, data] = await api.logout();
+    if (error) console.log('error logging in');
+    else {
+      console.log(data);
+      accessToken.value = '';
+      clearProfile();
+      await router.push('/');
+    }
   }
 
   const isAuthenticated = computed(() => {
@@ -52,8 +43,10 @@ export default function useAuth() {
   const refreshToken = async (initial: boolean): Promise<void> => {
 
     try {
-      const resp = await api.post<TokenResponse>('/api/auth/jwt/token/refresh/');
-      accessToken.value = resp.data.access;
+      const [error, data] = await api.refreshToken();
+      if (error) console.log('error refreshing token');
+
+      if (data) accessToken.value = data.access;
 
       // only load the profile and set interval when initial is true
       // this is used in App.vue
@@ -75,11 +68,12 @@ export default function useAuth() {
   const login = async (): Promise<void> => {
     try {
 
-      const resp = await api.post<TokenResponse>('/api/auth/jwt/token/', {
-        email: email.value, password: password.value,
-      }, { withCredentials: true });
-
-      accessToken.value = resp.data.access;
+      const [error, data] = await api.login({ email: email.value, password: password.value });
+      if (error) {
+        console.log('handle login error');
+        return
+      }
+      if (data) accessToken.value = data.access;
 
       await getProfile();
 
@@ -98,18 +92,8 @@ export default function useAuth() {
         message: 'Welcome to μblog!',
       });
 
-    } catch (exception) {
-      if (isAxiosError(exception) && exception.response) {
-
-        const e = exception as AxiosError;
-
-        if (e.response?.status === 401) {
-          Notify.create({
-            type: 'warning',
-            message: e.response.data.detail,
-          });
-        }
-      }
+    } catch (error) {
+      console.log(error)
     }
   }
   return { login, refreshToken, email, password, accessToken, isAuthenticated, logout }

--- a/quasar-app/src/modules/createPost.ts
+++ b/quasar-app/src/modules/createPost.ts
@@ -1,10 +1,6 @@
 import { ref } from 'vue';
-import { api } from 'boot/axios';
 import { useRouter } from 'vue-router';
-
-interface Post {
-  id: number;
-}
+import { apiService } from '../classes';
 
 export default function useCreatePost() {
 
@@ -14,19 +10,24 @@ export default function useCreatePost() {
 
   const createPost = async (): Promise<void> => {
 
+    // formData used for file upload with extra data
     const formData = new FormData();
+    formData.append('body', body.value);
+    if (image.value) {
+      formData.append('image', image.value);
+    };
 
-    try {
-      formData.append('body', body.value);
-      if (image.value) {
-        formData.append('image', image.value);
-      };
-      const resp = await api.post<Post>('/api/drf/fbv/posts/new/', formData);
-      const id: number = resp.data.id;
+    const [error, data] = await apiService.createPost(formData);
 
-      await router.push(`/posts/${id}`);
-    } catch (error) {
+    if (error) {
       console.error(error);
+      // TODO: handle error
+      return
+    }
+
+    if (data) {
+      // TODO: handle success
+      await router.push(`/posts/${data.id}`);
     }
   };
 

--- a/quasar-app/src/modules/debug.ts
+++ b/quasar-app/src/modules/debug.ts
@@ -1,12 +1,40 @@
-import { api } from 'boot/axios';
+import { apiService } from '../classes';
+import { Notify } from 'quasar';
 
 export default function useDebug() {
-  const triggerException = async () => {
-    void await api.post('/api/exception/');
+  const triggerException = async (): Promise<void> => {
+
+    const [error, data] = await apiService.triggerException();
+
+    if (error) {
+      Notify.create({
+        type: 'warning',
+        message: error?.response?.data.detail,
+      });
+    }
+
+    if (data) {
+      console.log('this code will never be reached');
+    }
   }
 
-  const emailAdmins = async () => {
-    void await api.post('/api/email-admins/');
+  const emailAdmins = async (): Promise<void> => {
+
+    const [error, data] = await apiService.emailAdmins();
+
+    if (error) {
+      Notify.create({
+        type: 'warning',
+        message: 'Could not email admins',
+      });
+    }
+
+    if (data) {
+      Notify.create({
+        type: 'success',
+        message: 'An email will be sent to the admins shortly',
+      });
+    }
   }
 
   return {

--- a/quasar-app/src/modules/posts.ts
+++ b/quasar-app/src/modules/posts.ts
@@ -1,6 +1,9 @@
 import { ref, computed, watch, reactive } from 'vue';
 import { api } from 'boot/axios';
+import { apiService } from '../classes';
 import usePagination from '../modules/pagination';
+
+import { GetPostsOptionsType, PostType } from '../types';
 
 interface User {
   email: string;
@@ -17,12 +20,7 @@ interface Post {
   modified_on: string;
 }
 
-interface Posts {
-  results: Post[];
-  count: number;
-}
-
-const postList = ref<Post[]>([]);
+const postList = ref<PostType[]>([]);
 const postCount = ref(0);
 const loadingPosts = ref(false);
 
@@ -71,9 +69,21 @@ export default function usePosts() {
 
   const getPosts = async (): Promise<void> => {
     loadingPosts.value = true;
-    const res = await api.get<Posts>('/api/drf/fbv/posts/', { params: { offset: offset.value * limit.value, limit: limit.value } });
-    postList.value = res.data?.results;
-    postCount.value = res.data?.count;
+    // get posts
+    const options: GetPostsOptionsType = { params: { offset: offset.value * limit.value, limit: limit.value } }
+    const [error, data] = await apiService.getPosts(options);
+
+    if (error) {
+      console.error(error);
+      // handle error
+      return
+
+    }
+    if (data) {
+      // handle success
+      postList.value = data.results;
+      postCount.value = data.count;
+    }
     loadingPosts.value = false;
   };
 

--- a/quasar-app/src/modules/posts.ts
+++ b/quasar-app/src/modules/posts.ts
@@ -1,5 +1,4 @@
 import { ref, computed, watch, reactive } from 'vue';
-import { api } from 'boot/axios';
 import { apiService } from '../classes';
 import usePagination from '../modules/pagination';
 
@@ -58,7 +57,18 @@ export function usePost() {
   };
 
   const deletePost = async (postId: number): Promise<void> => {
-    await api.delete(`/api/drf/fbv/posts/${postId}/`);
+    const [error, data] = await apiService.deletePost(postId);
+    if (error) {
+      //handle error
+      console.error(error)
+    }
+
+    if (data) {
+      // handle success
+
+      // TODO: implement component for deleting posts
+      console.log('post deleted')
+    }
   };
 
   return { post, getPost, deletePost, togglePostLike };

--- a/quasar-app/src/modules/posts.ts
+++ b/quasar-app/src/modules/posts.ts
@@ -5,31 +5,16 @@ import usePagination from '../modules/pagination';
 
 import { GetPostsOptionsType, PostType } from '../types';
 
-interface User {
-  email: string;
-  id: number;
-}
-
-interface Post {
-  body: string;
-  id: number;
-  image: string;
-  like_count: number;
-  liked: boolean;
-  created_by: User | null;
-  modified_on: string;
-}
-
 const postList = ref<PostType[]>([]);
 const postCount = ref(0);
 const loadingPosts = ref(false);
 
-const post = reactive<Post>({
+const post = reactive<PostType>({
   body: '',
   id: 0,
   image: '',
   like_count: 0,
-  created_by: null,
+  created_by: {email: '', id: 0},
   liked: false,
   modified_on: '1970-01-01T00:00:00.000000-00:00',
 });
@@ -53,16 +38,23 @@ export function usePost() {
 
   // use this for a single post
   const getPost = async (postId: number): Promise<void> => {
-    const res = await api.get<Post>(`/api/drf/fbv/posts/${postId}/`);
-    const postJson = res.data;
-    post.body = postJson.body;
-    post.id = postJson.id;
-    post.image = postJson.image;
-    post.like_count = postJson.like_count;
-    post.created_by = postJson.created_by;
-    post.liked = postJson.liked;
-    post.modified_on = postJson.modified_on;
-    console.log(postJson.modified_on);
+    const [error, data] = await apiService.getPost(postId);
+    if (error) {
+      //handle error
+      console.error(error)
+    }
+    if (data) {
+      // handle success
+
+      // Can this be simplified? Is there a way to assign multiple values to a reactive object at once?
+      post.body = data.body;
+      post.id = data.id;
+      post.image = data.image;
+      post.like_count = data.like_count;
+      post.liked = data.liked;
+      post.created_by = data.created_by;
+      post.modified_on = data.modified_on;
+    }
   };
 
   const deletePost = async (postId: number): Promise<void> => {

--- a/quasar-app/src/modules/posts.ts
+++ b/quasar-app/src/modules/posts.ts
@@ -36,9 +36,19 @@ const post = reactive<Post>({
 
 export function usePost() {
   const togglePostLike = async (postId: number): Promise<void> => {
-    const resp = await api.post<Post>(`/api/drf/fbv/posts/${postId}/like/`);
-    post.liked = resp.data.liked;
-    post.like_count = resp.data.like_count;
+    const [error, data] = await apiService.togglePostLike(postId);
+
+    if (error) {
+      console.error(error);
+      // handle error
+      return
+    }
+
+    if (data) {
+      // handle success
+      post.liked = data.liked;
+      post.like_count = data.like_count;
+    }
   };
 
   // use this for a single post

--- a/quasar-app/src/modules/profile.ts
+++ b/quasar-app/src/modules/profile.ts
@@ -1,10 +1,6 @@
 import { ref } from 'vue';
-import { api } from 'boot/axios';
+import { apiService } from '../classes'
 
-interface Profile {
-  email: string;
-  id: number;
-}
 
 const email = ref('');
 const userId = ref(0);
@@ -17,10 +13,16 @@ export default function useProfile() {
   };
 
   const getProfile = async (): Promise<void> => {
-    const resp = await api.get<Profile>('/api/profile/');
+    const [error, data] = await apiService.profile();
 
-    email.value = resp.data.email;
-    userId.value = resp.data.id;
+    if (error) {
+      console.error(error);
+      return
+    }
+    if (data) {
+      email.value = data.email;
+      userId.value = data.id;
+    }
   };
 
   return { getProfile, email, userId, clearProfile };

--- a/quasar-app/src/pages/Debug/index.vue
+++ b/quasar-app/src/pages/Debug/index.vue
@@ -17,8 +17,6 @@ export default defineComponent({
 
     const { triggerException, emailAdmins } = useDebug();
 
-
-
     return {
       triggerException, emailAdmins
     }

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -49,3 +49,18 @@ export interface PostType {
 }
 
 export type CreatePostResponse = [null, PostType] | [Error];
+
+export interface PostsType {
+  results: PostType[];
+  count: number;
+}
+
+export type GetPostsResponse = [null, PostsType] | [Error];
+
+type Params = {
+  offset?: number;
+  limit?: number;
+}
+export type GetPostsOptionsType = {
+  params: Params;
+}

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Types for API responses and other data
+ *
+ * https://stackoverflow.com/questions/37233735/interfaces-vs-types-in-typescript
+ */
+
+
+/**
+ * Interface for login data
+ */
+export interface LoginData {
+  email: string;
+  password: string;
+}
+
+export type TokenResponse = {
+  access: string;
+}
+
+export type LoginResponse = [null, TokenResponse] | [Error];
+
+
+export interface LogoutData {
+  message: string;
+};
+
+export type LogoutResponse = [null, LogoutData] | [Error];
+
+export type RefreshResponse = [null, TokenResponse] | [Error];

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -64,3 +64,5 @@ type Params = {
 export type GetPostsOptionsType = {
   params: Params;
 }
+
+export type TogglePostLikeResponse = [null, PostType] | [Error];

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -66,3 +66,5 @@ export type GetPostsOptionsType = {
 }
 
 export type TogglePostLikeResponse = [null, PostType] | [Error];
+
+export type GetPostResponse = [null, PostType] | [Error];

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -37,3 +37,15 @@ export interface ProfileType {
 }
 
 export type ProfileResponse = [null, ProfileType] | [Error];
+
+export interface PostType {
+  id: number;
+  body: string;
+  created_by: ProfileType,
+  image: string;
+  modified_on: string;
+  like_count: number;
+  liked: boolean;
+}
+
+export type CreatePostResponse = [null, PostType] | [Error];

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -8,6 +8,9 @@
 /**
  * Interface for login data
  */
+
+import { AxiosError } from 'axios';
+
 export interface LoginData {
   email: string;
   password: string;
@@ -68,3 +71,16 @@ export type GetPostsOptionsType = {
 export type TogglePostLikeResponse = [null, PostType] | [Error];
 
 export type GetPostResponse = [null, PostType] | [Error];
+
+export type ExceptionType = {
+  message: string;
+};
+
+// Is this the correct way to handle errors? Error vs AxiosError?
+type ExceptionError = { detail: string }
+export type ExceptionResponse = [null, ExceptionType] | [AxiosError<ExceptionError>];
+
+export type EmailAdminType = { message: string };
+
+export type EmailAdminResponse = [null, EmailAdminType] | [Error];
+

--- a/quasar-app/src/types/index.ts
+++ b/quasar-app/src/types/index.ts
@@ -27,3 +27,13 @@ export interface LogoutData {
 export type LogoutResponse = [null, LogoutData] | [Error];
 
 export type RefreshResponse = [null, TokenResponse] | [Error];
+
+/**
+ * Profile response and response data
+ */
+export interface ProfileType {
+  email: string;
+  id: number;
+}
+
+export type ProfileResponse = [null, ProfileType] | [Error];


### PR DESCRIPTION
This PR organizes all backend API calls into a class called `APIService` using a pattern described here: https://dev.to/blindkai/managing-api-layers-in-vue-js-with-typescript-hno. 